### PR TITLE
Fixing the email autolink error with certain jobs postings

### DIFF
--- a/nbbc.php
+++ b/nbbc.php
@@ -67,7 +67,7 @@ define('CHARSET', 'ISO-8859-1');
 define('REPLACE_FLAGS', ENT_COMPAT | ENT_XHTML);
 if (!function_exists('htmlspecialchars_54')) {
 function htmlspecialchars_54($string, $flags=REPLACE_FLAGS, $encoding=CHARSET, $double_encode=true) {
-return htmlspecialchars_54($string, $flags, $encoding, $double_encode);
+return htmlspecialchars($string, $flags, $encoding, $double_encode);
 }
 }
 

--- a/nbbc.php
+++ b/nbbc.php
@@ -1278,9 +1278,9 @@ $output = preg_split("/( (?:
 (?:https?|ftp) : \\/*
 (?:
 (?: (?: [a-zA-Z0-9-]{2,} \\. )+
-(?: arpa | com | org | net | edu | gov | mil | int | [a-z]{2}
+(?: arpa | com | org | net | edu | gov | mil | int
 | aero | biz | coop | info | museum | name | pro | games
-| example | invalid | localhost | test | local | onion | swift ) )
+| example | invalid | localhost | test | local | onion | swift | [a-z]{2} ) )
 | (?: [0-9]{1,3} \\. [0-9]{1,3} \\. [0-9]{1,3} \\. [0-9]{1,3} )
 | (?: [0-9A-Fa-f:]+ : [0-9A-Fa-f]{1,4} )
 )
@@ -1297,9 +1297,9 @@ $output = preg_split("/( (?:
 ) | (?:
 (?:
 (?: (?: [a-zA-Z0-9-]{2,} \\. )+
-(?: arpa | com | org | net | edu | gov | mil | int | [a-z]{2}
+(?: arpa | com | org | net | edu | gov | mil | int
 | aero | biz | coop | info | museum | name | pro | games
-| example | invalid | localhost | test | local | onion | swift ) )
+| example | invalid | localhost | test | local | onion | swift | [a-z]{2} ) )
 | (?: [0-9]{1,3} \\. [0-9]{1,3} \\. [0-9]{1,3} \\. [0-9]{1,3} )
 )
 (?: : [0-9]+ )?
@@ -1316,9 +1316,9 @@ $output = preg_split("/( (?:
 [a-zA-Z0-9._-]{2,} @
 (?:
 (?: (?: [a-zA-Z0-9-]{2,} \\. )+
-(?: arpa | com | org | net | edu | gov | mil | int | [a-z]{2}
+(?: arpa | com | org | net | edu | gov | mil | int
 | aero | biz | coop | info | museum | name | pro | games
-| example | invalid | localhost | test | local | onion | swift ) )
+| example | invalid | localhost | test | local | onion | swift | [a-z]{2} ) )
 | (?: [0-9]{1,3} \\. [0-9]{1,3} \\. [0-9]{1,3} \\. [0-9]{1,3} )
 )
 ) )/Dx", $string, -1, PREG_SPLIT_DELIM_CAPTURE);

--- a/nbbc.php
+++ b/nbbc.php
@@ -63,12 +63,12 @@ return $array;
 }
 }
 $BBCode_SourceDir = dirname(__FILE__);
-
 define('CHARSET', 'ISO-8859-1');
 define('REPLACE_FLAGS', ENT_COMPAT | ENT_XHTML);
-
+if (!function_exists('htmlspecialchars_54')) {
 function htmlspecialchars_54($string, $flags=REPLACE_FLAGS, $encoding=CHARSET, $double_encode=true) {
-    return htmlspecialchars($string, $flags, $encoding, $double_encode);
+return htmlspecialchars_54($string, $flags, $encoding, $double_encode);
+}
 }
 
 class BBCodeLexer {
@@ -1198,68 +1198,69 @@ $/Dx", $string);
 */
 }
 function HTMLEncode($string) {
-	if (!$this->allow_ampersand) 
-		return htmlspecialchars_54($string, ENT_COMPAT,'ISO-8859-1', true);
-	else return str_replace(Array('<', '>', '"'), Array('&lt;', '&gt;', '&quot;'), $string);
+if (!$this->allow_ampersand)
+return htmlspecialchars_54($string);
+else return str_replace(Array('<', '>', '"'),
+Array('&lt;', '&gt;', '&quot;'), $string);
 }
 function FixupOutput($string) {
-	if (!$this->detect_urls) {
-		$output = $this->Internal_ProcessSmileys($string);
-	}
-	else {
-		$chunks = $this->Internal_AutoDetectURLs($string);
-		$output = Array();
-		if (count($chunks)) {
-			$is_a_url = false;
-			foreach ($chunks as $index => $chunk) {
-				if (!$is_a_url) {
-					$chunk = $this->Internal_ProcessSmileys($chunk);
-				}
-				$output[] = $chunk;
-				$is_a_url = !$is_a_url;
-			}
-		}
-		$output = implode("", $output);
-	}
-	return $output;
+if (!$this->detect_urls) {
+$output = $this->Internal_ProcessSmileys($string);
+}
+else {
+$chunks = $this->Internal_AutoDetectURLs($string);
+$output = Array();
+if (count($chunks)) {
+$is_a_url = false;
+foreach ($chunks as $index => $chunk) {
+if (!$is_a_url) {
+$chunk = $this->Internal_ProcessSmileys($chunk);
+}
+$output[] = $chunk;
+$is_a_url = !$is_a_url;
+}
+}
+$output = implode("", $output);
+}
+return $output;
 }
 function Internal_ProcessSmileys($string) {
-	if (!$this->enable_smileys || $this->plain_mode) {
-		$output = $this->HTMLEncode($string);
-	}
-	else {
-	if ($this->smiley_regex === false) {
-	$this->Internal_RebuildSmileys();
-	}
-	$tokens = preg_split($this->smiley_regex, $string, -1, PREG_SPLIT_DELIM_CAPTURE);
-	if (count($tokens) <= 1) {
-	$output = $this->HTMLEncode($string);
-	}
-	else {
-	$output = "";
-	$is_a_smiley = false;
-	foreach ($tokens as $token) {
-	if (!$is_a_smiley) {
-	$output .= $this->HTMLEncode($token);
-	}
-	else {
-	if (isset($this->smiley_info[$token])) {
-	$info = $this->smiley_info[$token];
-	}
-	else {
-	$info = @getimagesize($this->smiley_dir . '/' . $this->smileys[$token]);
-	$this->smiley_info[$token] = $info;
-	}
-	$alt = htmlspecialchars_54($token);
-	$output .= "<img src=\"" . htmlspecialchars_54($this->smiley_url . '/' . $this->smileys[$token])
-	. "\" width=\"{$info[0]}\" height=\"{$info[1]}\""
-	. " alt=\"$alt\" title=\"$alt\" class=\"bbcode_smiley\" />";
-	}
-	$is_a_smiley = !$is_a_smiley;
-	}
-	}
-	}
-	return $output;
+if (!$this->enable_smileys || $this->plain_mode) {
+$output = $this->HTMLEncode($string);
+}
+else {
+if ($this->smiley_regex === false) {
+$this->Internal_RebuildSmileys();
+}
+$tokens = preg_split($this->smiley_regex, $string, -1, PREG_SPLIT_DELIM_CAPTURE);
+if (count($tokens) <= 1) {
+$output = $this->HTMLEncode($string);
+}
+else {
+$output = "";
+$is_a_smiley = false;
+foreach ($tokens as $token) {
+if (!$is_a_smiley) {
+$output .= $this->HTMLEncode($token);
+}
+else {
+if (isset($this->smiley_info[$token])) {
+$info = $this->smiley_info[$token];
+}
+else {
+$info = @getimagesize($this->smiley_dir . '/' . $this->smileys[$token]);
+$this->smiley_info[$token] = $info;
+}
+$alt = htmlspecialchars_54($token);
+$output .= "<img src=\"" . htmlspecialchars_54($this->smiley_url . '/' . $this->smileys[$token])
+. "\" width=\"{$info[0]}\" height=\"{$info[1]}\""
+. " alt=\"$alt\" title=\"$alt\" class=\"bbcode_smiley\" />";
+}
+$is_a_smiley = !$is_a_smiley;
+}
+}
+}
+return $output;
 }
 function Internal_RebuildSmileys() {
 $regex = Array("/(?<![\\w])(");
@@ -1278,7 +1279,7 @@ $output = preg_split("/( (?:
 (?:
 (?: (?: [a-zA-Z0-9-]{2,} \\. )+
 (?: arpa | com | org | net | edu | gov | mil | int | [a-z]{2}
-| aero | biz | coop | info | museum | name | pro
+| aero | biz | coop | info | museum | name | pro | games
 | example | invalid | localhost | test | local | onion | swift ) )
 | (?: [0-9]{1,3} \\. [0-9]{1,3} \\. [0-9]{1,3} \\. [0-9]{1,3} )
 | (?: [0-9A-Fa-f:]+ : [0-9A-Fa-f]{1,4} )
@@ -1297,7 +1298,7 @@ $output = preg_split("/( (?:
 (?:
 (?: (?: [a-zA-Z0-9-]{2,} \\. )+
 (?: arpa | com | org | net | edu | gov | mil | int | [a-z]{2}
-| aero | biz | coop | info | museum | name | pro
+| aero | biz | coop | info | museum | name | pro | games
 | example | invalid | localhost | test | local | onion | swift ) )
 | (?: [0-9]{1,3} \\. [0-9]{1,3} \\. [0-9]{1,3} \\. [0-9]{1,3} )
 )
@@ -1315,8 +1316,8 @@ $output = preg_split("/( (?:
 [a-zA-Z0-9._-]{2,} @
 (?:
 (?: (?: [a-zA-Z0-9-]{2,} \\. )+
-(?: arpa | com | org | net | edu | gov | mil | int
-| aero | biz | coop | info | museum | name | pro | [a-z]{2}
+(?: arpa | com | org | net | edu | gov | mil | int | [a-z]{2}
+| aero | biz | coop | info | museum | name | pro | games
 | example | invalid | localhost | test | local | onion | swift ) )
 | (?: [0-9]{1,3} \\. [0-9]{1,3} \\. [0-9]{1,3} \\. [0-9]{1,3} )
 )
@@ -1930,124 +1931,127 @@ BBCODE_STACK_CLASS => $this->current_class,
 );
 }
 function Parse($string) {
-
-	$this->lexer = new BBCodeLexer($string, $this->tag_marker);
-	$this->lexer->debug = $this->debug;
-	$old_output_limit = $this->output_limit;
-	if ($this->output_limit > 0) {
-		if (strlen($string) < $this->output_limit) {
-			$this->output_limit = 0;
-		}
-		else if ($this->limit_precision > 0) {
-			$guess_length = $this->lexer->GuessTextLength();
-			if ($guess_length < $this->output_limit * ($this->limit_precision + 1.0)) {
-				$this->output_limit = 0;
-			}
-			else {
-			}
-		}
-	}
-	$this->stack = Array();
-	$this->start_tags = Array();
-	$this->lost_start_tags = Array();
-	$this->text_length = 0;
-	$this->was_limited = false;
-	if (strlen($this->pre_trim) > 0)
-	$this->Internal_CleanupWSByEatingInput($this->pre_trim);
-	$newline = $this->plain_mode ? "\n" : "<br />\n";
-	while (true) {
-		if (($token_type = $this->lexer->NextToken()) == BBCODE_EOI) {
-			break;
-		}
-		switch ($token_type) {
-			case BBCODE_TEXT:
-				if ($this->output_limit > 0 && $this->text_length + strlen($this->lexer->text) >= $this->output_limit) {
-					$text = $this->Internal_LimitText($this->lexer->text,
-					$this->output_limit - $this->text_length);
-					if (strlen($text) > 0) {
-						$this->text_length += strlen($text);
-						$this->stack[] = Array(
-						BBCODE_STACK_TOKEN => BBCODE_TEXT,
-						BBCODE_STACK_TEXT => $this->FixupOutput($text),
-						BBCODE_STACK_TAG => false,
-						BBCODE_STACK_CLASS => $this->current_class,
-						);
-					}
-					$this->Internal_DoLimit();
-					break 2;
-				}
-				$this->text_length += strlen($this->lexer->text);
-				$this->stack[] = Array(
-					BBCODE_STACK_TOKEN => BBCODE_TEXT,
-					BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
-					BBCODE_STACK_TAG => false,
-					BBCODE_STACK_CLASS => $this->current_class,
-				);
-				break;
-			case BBCODE_WS:
-				if ($this->output_limit > 0 && $this->text_length + strlen($this->lexer->text) >= $this->output_limit) {
-					$this->Internal_DoLimit();
-					break 2;
-				}
-				$this->text_length += strlen($this->lexer->text);
-				$this->stack[] = Array(
-					BBCODE_STACK_TOKEN => BBCODE_WS,
-					BBCODE_STACK_TEXT => $this->lexer->text,
-					BBCODE_STACK_TAG => false,
-					BBCODE_STACK_CLASS => $this->current_class,
-				);
-				break;
-			case BBCODE_NL:
-				if ($this->ignore_newlines) {
-					if ($this->output_limit > 0 && $this->text_length + 1 >= $this->output_limit) {
-						$this->Internal_DoLimit();
-						break 2;
-					}
-					$this->text_length += 1;
-					$this->stack[] = Array(
-						BBCODE_STACK_TOKEN => BBCODE_WS,
-						BBCODE_STACK_TEXT => "\n",
-						BBCODE_STACK_TAG => false,
-						BBCODE_STACK_CLASS => $this->current_class,
-					);
-				}
-				else {
-					$this->Internal_CleanupWSByPoppingStack("s", $this->stack);
-					if ($this->output_limit > 0 && $this->text_length + 1 >= $this->output_limit) {
-						$this->Internal_DoLimit();
-						break 2;
-					}
-					$this->text_length += 1;
-					$this->stack[] = Array(
-						BBCODE_STACK_TOKEN => BBCODE_NL,
-						BBCODE_STACK_TEXT => $newline,
-						BBCODE_STACK_TAG => false,
-						BBCODE_STACK_CLASS => $this->current_class,
-					);
-					$this->Internal_CleanupWSByEatingInput("s");
-				}
-				break;
-			case BBCODE_TAG:
-				$this->Internal_ParseStartTagToken();
-				break;
-			case BBCODE_ENDTAG:
-				$this->Internal_ParseEndTagToken();
-				break;
-			default:
-				break;
-		}
-		}
-		if (strlen($this->post_trim) > 0)
-			$this->Internal_CleanupWSByPoppingStack($this->post_trim, $this->stack);
-			$result = $this->Internal_GenerateOutput(0);
-			$result = $this->Internal_CollectTextReverse($result, count($result) - 1);
-			$this->output_limit = $old_output_limit;
-			if ($this->plain_mode) {
-			$result = preg_replace("/[\\x00-\\x09\\x0B-\\x20]+/", " ", $result);
-			$result = preg_replace("/(?:[\\x20]*\\n){2,}[\\x20]*/", "\n\n", $result);
-			$result = trim($result);
-		}
-		return $result;
-	}
+$this->lexer = new BBCodeLexer($string, $this->tag_marker);
+$this->lexer->debug = $this->debug;
+$old_output_limit = $this->output_limit;
+if ($this->output_limit > 0) {
+if (strlen($string) < $this->output_limit) {
+$this->output_limit = 0;
+}
+else if ($this->limit_precision > 0) {
+$guess_length = $this->lexer->GuessTextLength();
+if ($guess_length < $this->output_limit * ($this->limit_precision + 1.0)) {
+$this->output_limit = 0;
+}
+else {
+}
+}
+}
+$this->stack = Array();
+$this->start_tags = Array();
+$this->lost_start_tags = Array();
+$this->text_length = 0;
+$this->was_limited = false;
+if (strlen($this->pre_trim) > 0)
+$this->Internal_CleanupWSByEatingInput($this->pre_trim);
+$newline = $this->plain_mode ? "\n" : "<br />\n";
+while (true) {
+if (($token_type = $this->lexer->NextToken()) == BBCODE_EOI) {
+break;
+}
+switch ($token_type) {
+case BBCODE_TEXT:
+if ($this->output_limit > 0
+&& $this->text_length + strlen($this->lexer->text) >= $this->output_limit) {
+$text = $this->Internal_LimitText($this->lexer->text,
+$this->output_limit - $this->text_length);
+if (strlen($text) > 0) {
+$this->text_length += strlen($text);
+$this->stack[] = Array(
+BBCODE_STACK_TOKEN => BBCODE_TEXT,
+BBCODE_STACK_TEXT => $this->FixupOutput($text),
+BBCODE_STACK_TAG => false,
+BBCODE_STACK_CLASS => $this->current_class,
+);
+}
+$this->Internal_DoLimit();
+break 2;
+}
+$this->text_length += strlen($this->lexer->text);
+$this->stack[] = Array(
+BBCODE_STACK_TOKEN => BBCODE_TEXT,
+BBCODE_STACK_TEXT => $this->FixupOutput($this->lexer->text),
+BBCODE_STACK_TAG => false,
+BBCODE_STACK_CLASS => $this->current_class,
+);
+break;
+case BBCODE_WS:
+if ($this->output_limit > 0
+&& $this->text_length + strlen($this->lexer->text) >= $this->output_limit) {
+$this->Internal_DoLimit();
+break 2;
+}
+$this->text_length += strlen($this->lexer->text);
+$this->stack[] = Array(
+BBCODE_STACK_TOKEN => BBCODE_WS,
+BBCODE_STACK_TEXT => $this->lexer->text,
+BBCODE_STACK_TAG => false,
+BBCODE_STACK_CLASS => $this->current_class,
+);
+break;
+case BBCODE_NL:
+if ($this->ignore_newlines) {
+if ($this->output_limit > 0
+&& $this->text_length + 1 >= $this->output_limit) {
+$this->Internal_DoLimit();
+break 2;
+}
+$this->text_length += 1;
+$this->stack[] = Array(
+BBCODE_STACK_TOKEN => BBCODE_WS,
+BBCODE_STACK_TEXT => "\n",
+BBCODE_STACK_TAG => false,
+BBCODE_STACK_CLASS => $this->current_class,
+);
+}
+else {
+$this->Internal_CleanupWSByPoppingStack("s", $this->stack);
+if ($this->output_limit > 0
+&& $this->text_length + 1 >= $this->output_limit) {
+$this->Internal_DoLimit();
+break 2;
+}
+$this->text_length += 1;
+$this->stack[] = Array(
+BBCODE_STACK_TOKEN => BBCODE_NL,
+BBCODE_STACK_TEXT => $newline,
+BBCODE_STACK_TAG => false,
+BBCODE_STACK_CLASS => $this->current_class,
+);
+$this->Internal_CleanupWSByEatingInput("s");
+}
+break;
+case BBCODE_TAG:
+$this->Internal_ParseStartTagToken();
+break;
+case BBCODE_ENDTAG:
+$this->Internal_ParseEndTagToken();
+break;
+default:
+break;
+}
+}
+if (strlen($this->post_trim) > 0)
+$this->Internal_CleanupWSByPoppingStack($this->post_trim, $this->stack);
+$result = $this->Internal_GenerateOutput(0);
+$result = $this->Internal_CollectTextReverse($result, count($result) - 1);
+$this->output_limit = $old_output_limit;
+if ($this->plain_mode) {
+$result = preg_replace("/[\\x00-\\x09\\x0B-\\x20]+/", " ", $result);
+$result = preg_replace("/(?:[\\x20]*\\n){2,}[\\x20]*/", "\n\n", $result);
+$result = trim($result);
+}
+return $result;
+}
 }
 

--- a/src/nbbc_lex.php
+++ b/src/nbbc_lex.php
@@ -410,7 +410,7 @@
 		function Internal_DecodeTag($tag) {
 
 			if ($this->debug) {
-				print "<b>Lexer::InternalDecodeTag:</b> input: " . htmlspecialchars($tag) . "<br />\n";
+				print "<b>Lexer::InternalDecodeTag:</b> input: " . htmlspecialchars_54($tag) . "<br />\n";
 			}
 
 			// Create the initial result object.
@@ -580,7 +580,7 @@
 				ob_start();
 				print_r($result);
 				$output = ob_get_clean();
-				print htmlspecialchars($output) . "<br />\n";
+				print htmlspecialchars_54($output) . "<br />\n";
 			}
 
 			// Save the resulting parameters, and return the whole shebang.

--- a/src/nbbc_lib.php
+++ b/src/nbbc_lib.php
@@ -415,14 +415,14 @@
 				if ($bbcode->debug)
 					print "ISVALIDURL<br />";
 				if ($bbcode->url_targetable !== false && isset($params['target']))
-					$target = " target=\"" . htmlspecialchars($params['target']) . "\"";
+					$target = " target=\"" . htmlspecialchars_54($params['target']) . "\"";
 				else $target = "";
 				if ($bbcode->url_target !== false)
 					if (!($bbcode->url_targetable == 'override' && isset($params['target'])))
-						$target = " target=\"" . htmlspecialchars($bbcode->url_target) . "\"";
-				return '<a href="' . htmlspecialchars($url) . '" class="bbcode_url"' . $target . '>' . $content . '</a>';
+						$target = " target=\"" . htmlspecialchars_54($bbcode->url_target) . "\"";
+				return '<a href="' . htmlspecialchars_54($url) . '" class="bbcode_url"' . $target . '>' . $content . '</a>';
 			}
-			else return htmlspecialchars($params['_tag']) . $content . htmlspecialchars($params['_endtag']);
+			else return htmlspecialchars_54($params['_tag']) . $content . htmlspecialchars_54($params['_endtag']);
 		}
 
 		// Format an [email] tag by producing an <a>...</a> element.
@@ -435,8 +435,8 @@
 
 			$email = is_string($default) ? $default : $bbcode->UnHTMLEncode(strip_tags($content));
 			if ($bbcode->IsValidEmail($email))
-				return '<a href="mailto:' . htmlspecialchars($email) . '" class="bbcode_email">' . $content . '</a>';
-			else return htmlspecialchars($params['_tag']) . $content . htmlspecialchars($params['_endtag']);
+				return '<a href="mailto:' . htmlspecialchars_54($email) . '" class="bbcode_email">' . $content . '</a>';
+			else return htmlspecialchars_54($params['_tag']) . $content . htmlspecialchars_54($params['_endtag']);
 		}
 		
 		// Format a [size] tag by producing a <span> with a style with a different font-size.
@@ -494,7 +494,7 @@
 			$title = trim(@$params['title']);
 			if (strlen($title) <= 0) $title = trim($default);
 			return "<a href=\"{$bbcode->wiki_url}$name\" class=\"bbcode_wiki\">"
-				. htmlspecialchars($title) . "</a>";
+				. htmlspecialchars_54($title) . "</a>";
 		}
 
 		// Format an [img] tag.  The URL only allows http, https, and ftp protocols for safety.
@@ -510,21 +510,21 @@
 						$info = @getimagesize("{$bbcode->local_img_dir}/{$content}");
 						if ($info[2] == IMAGETYPE_GIF || $info[2] == IMAGETYPE_JPEG || $info[2] == IMAGETYPE_PNG) {
 							return "<img src=\""
-								. htmlspecialchars("{$bbcode->local_img_url}/{$content}") . "\" alt=\""
-								. htmlspecialchars(basename($content)) . "\" width=\""
-								. htmlspecialchars($info[0]) . "\" height=\""
-								. htmlspecialchars($info[1]) . "\" class=\"bbcode_img\" />";
+								. htmlspecialchars_54("{$bbcode->local_img_url}/{$content}") . "\" alt=\""
+								. htmlspecialchars_54(basename($content)) . "\" width=\""
+								. htmlspecialchars_54($info[0]) . "\" height=\""
+								. htmlspecialchars_54($info[1]) . "\" class=\"bbcode_img\" />";
 						}
 					}
 				}
 				else if ($bbcode->IsValidURL($content, false)) {
 					// Remote URL, or at least we don't know where it is.
-					return "<img src=\"" . htmlspecialchars($content) . "\" alt=\""
-						. htmlspecialchars(basename($content)) . "\" class=\"bbcode_img\" />";
+					return "<img src=\"" . htmlspecialchars_54($content) . "\" alt=\""
+						. htmlspecialchars_54(basename($content)) . "\" class=\"bbcode_img\" />";
 				}
 			}
 
-			return htmlspecialchars($params['_tag']) . htmlspecialchars($content) . htmlspecialchars($params['_endtag']);
+			return htmlspecialchars_54($params['_tag']) . htmlspecialchars_54($content) . htmlspecialchars_54($params['_endtag']);
 		}
 
 		// Format a [rule] tag.  This substitutes the content provided by the BBCode
@@ -551,19 +551,19 @@
 			if ($action == BBCODE_CHECK) return true;
 
 			if (isset($params['name'])) {
-				$title = htmlspecialchars(trim($params['name'])) . " wrote";
+				$title = htmlspecialchars_54(trim($params['name'])) . " wrote";
 				if (isset($params['date']))
-					$title .= " on " . htmlspecialchars(trim($params['date']));
+					$title .= " on " . htmlspecialchars_54(trim($params['date']));
 				$title .= ":";
 				if (isset($params['url'])) {
 					$url = trim($params['url']);
 					if ($bbcode->IsValidURL($url))
-						$title = "<a href=\"" . htmlspecialchars($params['url']) . "\">" . $title . "</a>";
+						$title = "<a href=\"" . htmlspecialchars_54($params['url']) . "\">" . $title . "</a>";
 				}
 			}
 			else if (!is_string($default))
 				$title = "Quote:";
-			else $title = htmlspecialchars(trim($default)) . " wrote:";
+			else $title = htmlspecialchars_54(trim($default)) . " wrote:";
 			return "\n<div class=\"bbcode_quote\">\n<div class=\"bbcode_quote_head\">"
 				. $title . "</div>\n<div class=\"bbcode_quote_body\">"
 				. $content . "</div>\n</div>\n";

--- a/src/nbbc_main.php
+++ b/src/nbbc_main.php
@@ -115,7 +115,7 @@
 			print "<div>Profiled times:\n<ul>\n";
 			ksort($this->total_times);
 			foreach ($this->total_times as $name => $time) {
-				print "<li><b>" . htmlspecialchars($name) . "</b>: " . sprintf("%0.2f msec", $time * 1000) . "</li>\n";
+				print "<li><b>" . htmlspecialchars_54($name) . "</b>: " . sprintf("%0.2f msec", $time * 1000) . "</li>\n";
 			}
 			print "</ul>\n</div>\n";
 		}
@@ -140,6 +140,14 @@
 	// of PHP, including a file that uses a relative pathname doesn't always work
 	// correctly due to the way include_path is set.
 	$BBCode_SourceDir = dirname(__FILE__);
+
+	define('CHARSET', 'ISO-8859-1');
+	define('REPLACE_FLAGS', ENT_COMPAT | ENT_XHTML);
+	if (!function_exists('htmlspecialchars_54')) {
+		function htmlspecialchars_54($string, $flags=REPLACE_FLAGS, $encoding=CHARSET, $double_encode=true) {
+    		return htmlspecialchars_54($string, $flags, $encoding, $double_encode);
+		}
+	}
 
 	require_once("$BBCode_SourceDir/nbbc_lex.php");		// The lexical analyzer.
 	require_once("$BBCode_SourceDir/nbbc_parse.php");	// The parser/converter.

--- a/src/nbbc_main.php
+++ b/src/nbbc_main.php
@@ -145,7 +145,7 @@
 	define('REPLACE_FLAGS', ENT_COMPAT | ENT_XHTML);
 	if (!function_exists('htmlspecialchars_54')) {
 		function htmlspecialchars_54($string, $flags=REPLACE_FLAGS, $encoding=CHARSET, $double_encode=true) {
-    		return htmlspecialchars_54($string, $flags, $encoding, $double_encode);
+    		return htmlspecialchars($string, $flags, $encoding, $double_encode);
 		}
 	}
 

--- a/src/nbbc_parse.php
+++ b/src/nbbc_parse.php
@@ -573,9 +573,9 @@
 					(?:https?|ftp) : \\/*
 					(?:
 						(?: (?: [a-zA-Z0-9-]{2,} \\. )+
-							(?: arpa | com | org | net | edu | gov | mil | int | [a-z]{2}
+							(?: arpa | com | org | net | edu | gov | mil | int
 								| aero | biz | coop | info | museum | name | pro | games
-								| example | invalid | localhost | test | local | onion | swift ) )
+								| example | invalid | localhost | test | local | onion | swift | [a-z]{2} ) )
 						| (?: [0-9]{1,3} \\. [0-9]{1,3} \\. [0-9]{1,3} \\. [0-9]{1,3} )
 						| (?: [0-9A-Fa-f:]+ : [0-9A-Fa-f]{1,4} )
 					)
@@ -592,9 +592,9 @@
 				) | (?:
 					(?:
 						(?: (?: [a-zA-Z0-9-]{2,} \\. )+
-							(?: arpa | com | org | net | edu | gov | mil | int | [a-z]{2}
+							(?: arpa | com | org | net | edu | gov | mil | int
 								| aero | biz | coop | info | museum | name | pro | games
-								| example | invalid | localhost | test | local | onion | swift ) )
+								| example | invalid | localhost | test | local | onion | swift | [a-z]{2} ) )
 						| (?: [0-9]{1,3} \\. [0-9]{1,3} \\. [0-9]{1,3} \\. [0-9]{1,3} )
 					)
 					(?: : [0-9]+ )?
@@ -611,9 +611,9 @@
 					[a-zA-Z0-9._-]{2,} @
 					(?:
 						(?: (?: [a-zA-Z0-9-]{2,} \\. )+
-							(?: arpa | com | org | net | edu | gov | mil | int | [a-z]{2}
+							(?: arpa | com | org | net | edu | gov | mil | int
 								| aero | biz | coop | info | museum | name | pro | games
-								| example | invalid | localhost | test | local | onion | swift ) )
+								| example | invalid | localhost | test | local | onion | swift | [a-z]{2} ) )
 						| (?: [0-9]{1,3} \\. [0-9]{1,3} \\. [0-9]{1,3} \\. [0-9]{1,3} )
 					)
 				) )/Dx", $string, -1, PREG_SPLIT_DELIM_CAPTURE);

--- a/src/nbbc_parse.php
+++ b/src/nbbc_parse.php
@@ -88,7 +88,7 @@
 		var $root_class;	// The root container class.
 		var $lost_start_tags; // For repair when tags are badly mis-nested.
 		var $start_tags;	// An associative array of locations of start tags on the stack.
-		var $allow_ampersand; // If true, we use str_replace() instead of htmlspecialchars().
+		var $allow_ampersand; // If true, we use str_replace() instead of htmlspecialchars_54().
 		var $tag_marker;	// Set to '[', '<', '{', or '('.
 		var $ignore_newlines; // If true, newlines will be treated as normal whitespace.
 		var $plain_mode;	// Don't output tags:  Just output text/whitespace/newlines only.
@@ -391,18 +391,18 @@
 		*/
 		}
 
-		// This function is used to wrap around calls to htmlspecialchars() for
+		// This function is used to wrap around calls to htmlspecialchars_54() for
 		// plain text so that you can add your own text-evaluation code if you want.
 		// For example, you might want to make *foo* turn into <b>foo</b>, or
-		// something like that.  The default behavior is just to call htmlspecialchars()
+		// something like that.  The default behavior is just to call htmlspecialchars_54()
 		// and be done with it, but if you inherit and override this function, you
 		// can do pretty much anything you want.
 		//
-		// Note that htmlspecialchars() is still used directly for doing things like
+		// Note that htmlspecialchars_54() is still used directly for doing things like
 		// cleaning up URLs in tags; this function is applied to *plain* *text* *only*.
 		function HTMLEncode($string) {
 			if (!$this->allow_ampersand)
-				return htmlspecialchars($string);
+				return htmlspecialchars_54($string);
 			else return str_replace(Array('<', '>', '"'),
 					Array('&lt;', '&gt;', '&quot;'), $string);
 		}
@@ -416,7 +416,7 @@
 			$BBCode_Profiler->Begin('FixupOutput');
 
 			if ($this->debug)
-				print "<b>FixupOutput:</b> input: <tt>" . htmlspecialchars($string) . "</tt><br />\n";
+				print "<b>FixupOutput:</b> input: <tt>" . htmlspecialchars_54($string) . "</tt><br />\n";
 
 			if (!$this->detect_urls) {
 				// Easy case:  No URL-decoding, so don't take the time to do it.
@@ -452,7 +452,7 @@
 			}
 
 			if ($this->debug)
-				print "<b>FixupOutput:</b> output: <tt>" . htmlspecialchars($output) . "</tt><br />\n";
+				print "<b>FixupOutput:</b> output: <tt>" . htmlspecialchars_54($output) . "</tt><br />\n";
 
 			$BBCode_Profiler->End('FixupOutput');
 
@@ -509,8 +509,8 @@
 								$info = @getimagesize($this->smiley_dir . '/' . $this->smileys[$token]);
 								$this->smiley_info[$token] = $info;
 							}
-							$alt = htmlspecialchars($token);
-							$output .= "<img src=\"" . htmlspecialchars($this->smiley_url . '/' . $this->smileys[$token])
+							$alt = htmlspecialchars_54($token);
+							$output .= "<img src=\"" . htmlspecialchars_54($this->smiley_url . '/' . $this->smileys[$token])
 								. "\" width=\"{$info[0]}\" height=\"{$info[1]}\""
 								. " alt=\"$alt\" title=\"$alt\" class=\"bbcode_smiley\" />";
 						}
@@ -540,7 +540,7 @@
 			$this->smiley_regex = implode("", $regex);
 
 			if ($this->debug)
-				print "<b>Internal_RebuildSmileys:</b> regex: <tt>" . htmlspecialchars($regex) . "</tt><br />\n";
+				print "<b>Internal_RebuildSmileys:</b> regex: <tt>" . htmlspecialchars_54($regex) . "</tt><br />\n";
 		}
 
 		// Search through the input for URLs, or things that are URL-like.  We search
@@ -680,7 +680,7 @@
 		//        control codes and tabs, to be collapsed into individual space characters.
 		//
 		//   e - Apply HTMLEncode().
-		//   h - Apply htmlspecialchars().
+		//   h - Apply htmlspecialchars_54().
 		//   k - Apply Wikify().
 		//   u - Apply urlencode().
 		//
@@ -702,14 +702,14 @@
 				if (!$is_an_insert) {
 					if ($this->debug) {
 						print "<b>FormatInserts:</b> add text: <tt>"
-							. htmlspecialchars($piece) . "</tt><br />\n";
+							. htmlspecialchars_54($piece) . "</tt><br />\n";
 					}
 					$result[] = $piece;
 				}
 				else if (!preg_match('/\{\$([a-zA-Z0-9_:-]+)((?:\\.[a-zA-Z0-9_:-]+)*)(?:\/([a-zA-Z0-9_:-]+))?\}/', $piece, $matches)) {
 					if ($this->debug) {
 						print "<b>FormatInserts:</b> not an insert: add as text: <tt>"
-							. htmlspecialchars($piece) . "</tt><br />\n";
+							. htmlspecialchars_54($piece) . "</tt><br />\n";
 					}
 					$result[] = $piece;
 				}
@@ -756,14 +756,14 @@
 						if      (isset($flags['b'])) $value = basename($value);
 						if      (isset($flags['e'])) $value = $this->HTMLEncode($value);
 						else if (isset($flags['k'])) $value = $this->Wikify($value);
-						else if (isset($flags['h'])) $value = htmlspecialchars($value);
+						else if (isset($flags['h'])) $value = htmlspecialchars_54($value);
 						else if (isset($flags['u'])) $value = urlencode($value);
 						if      (isset($flags['n'])) $value = $this->nl2br($value);
 					}
 					
 					if ($this->debug) {
-						print "<b>FormatInserts:</b> add insert: <tt>" . htmlspecialchars($piece)
-							. "</tt> --&gt; <tt>" . htmlspecialchars($value) . "</tt><br />\n";
+						print "<b>FormatInserts:</b> add insert: <tt>" . htmlspecialchars_54($piece)
+							. "</tt> --&gt; <tt>" . htmlspecialchars_54($value) . "</tt><br />\n";
 					}
 					
 					// Append the value to the output.
@@ -835,7 +835,7 @@
 					$output[] = $token;
 					if ($this->debug) {
 						print "<b>Internal_GenerateOutput:</b> push text: <tt>"
-							. htmlspecialchars($token[BBCODE_STACK_TEXT]) . "</tt><br />\n";
+							. htmlspecialchars_54($token[BBCODE_STACK_TEXT]) . "</tt><br />\n";
 					}
 				}
 				else {
@@ -864,7 +864,7 @@
 						);
 						if ($this->debug) {
 							print "<b>Internal_GenerateOutput:</b> push broken tag: <tt>"
-								. htmlspecialchars($token['text']) . "</tt><br />\n";
+								. htmlspecialchars_54($token['text']) . "</tt><br />\n";
 						}
 					}
 					else {
@@ -873,7 +873,7 @@
 						// processed with the current output as its content.
 						if ($this->debug) {
 							print "<b>Internal_GenerateOutput:</b> found start tag with optional end tag: <tt>"
-								. htmlspecialchars($token[BBCODE_STACK_TEXT]) . "</tt><br />\n";
+								. htmlspecialchars_54($token[BBCODE_STACK_TEXT]) . "</tt><br />\n";
 						}
 
 						// If this was supposed to have an end tag, and we find a floating one
@@ -893,7 +893,7 @@
 
 						if ($this->debug) {
 							print "<b>Internal_GenerateOutput:</b> optional-tag's content: <tt>"
-								. htmlspecialchars($tag_body) . "</tt><br />\n";
+								. htmlspecialchars_54($tag_body) . "</tt><br />\n";
 						}
 
 						$this->Internal_UpdateParamsForMissingEndTag(@$token[BBCODE_STACK_TAG]);
@@ -902,7 +902,7 @@
 							
 						if ($this->debug) {
 							print "<b>Internal_GenerateOutput:</b> push optional-tag's output: <tt>"
-								. htmlspecialchars($tag_output) . "</tt><br />\n";
+								. htmlspecialchars_54($tag_output) . "</tt><br />\n";
 						}
 								
 						$output = Array(Array(
@@ -918,7 +918,7 @@
 				print "<b>Internal_GenerateOutput:</b> done; output contains " . count($output) . " items: <tt>"
 					. $this->Internal_DumpStack($output) . "</tt><br />\n";
 				$noutput = $this->Internal_CollectTextReverse($output, count($output) - 1);
-				print "<b>Internal_GenerateOutput:</b> output: <tt>" . htmlspecialchars($noutput) . "</tt><br />\n";
+				print "<b>Internal_GenerateOutput:</b> output: <tt>" . htmlspecialchars_54($noutput) . "</tt><br />\n";
 				print "<b>Internal_GenerateOutput:</b> Stack contents: <tt>" . $this->Internal_DumpStack() . "</tt><br />\n";
 			}
 			$this->Internal_ComputeCurrentClass();
@@ -986,7 +986,7 @@
 			if ($this->debug) {
 				print "<b>Internal_FinishTag:</b> stack has " . count($this->stack)
 					. " items; searching for start tag for <tt>[/"
-					. htmlspecialchars($tag_name) . "]</tt><br />\n";
+					. htmlspecialchars_54($tag_name) . "]</tt><br />\n";
 			}
 
 			// If this is a malformed tag like [/], tell them now, since there's
@@ -1051,7 +1051,7 @@
 			$this->Internal_ComputeCurrentClass();
 			
 			if ($this->debug)
-				print "<b>Internal_FinishTag:</b> output: <tt>" . htmlspecialchars($output) . "</tt><br />\n";
+				print "<b>Internal_FinishTag:</b> output: <tt>" . htmlspecialchars_54($output) . "</tt><br />\n";
 
 			return $output;
 		}
@@ -1063,7 +1063,7 @@
 			else $this->current_class = $this->root_class;
 			if ($this->debug) {
 				print "<b>Internal_ComputeCurrentClass:</b> current class is now \"<tt>"
-					. htmlspecialchars($this->current_class) . "</tt>\"<br />\n";
+					. htmlspecialchars_54($this->current_class) . "</tt>\"<br />\n";
 			}
 		}
 
@@ -1077,7 +1077,7 @@
 			foreach ($array as $item) {
 				switch (@$item[BBCODE_STACK_TOKEN]) {
 				case BBCODE_TEXT:
-					$string .= "\"" . htmlspecialchars(@$item[BBCODE_STACK_TEXT]) . "\" ";
+					$string .= "\"" . htmlspecialchars_54(@$item[BBCODE_STACK_TEXT]) . "\" ";
 					break;
 				case BBCODE_WS:
 					$string .= "WS ";
@@ -1086,7 +1086,7 @@
 					$string .= "NL ";
 					break;
 				case BBCODE_TAG:
-					$string .= "[" . htmlspecialchars(@$item[BBCODE_STACK_TAG]['_name']) . "] ";
+					$string .= "[" . htmlspecialchars_54(@$item[BBCODE_STACK_TAG]['_name']) . "] ";
 					break;
 				default:
 					$string .= "unknown ";
@@ -1106,7 +1106,7 @@
 			if ($this->debug) {
 				print "<b>Internal_CleanupWSByPoppingStack:</b> array has " . count($array)
 					. " items; pattern=\"<tt>"
-					. htmlspecialchars($pattern) . "</tt>\"<br />\n";
+					. htmlspecialchars_54($pattern) . "</tt>\"<br />\n";
 			}
 
 			if (strlen($pattern) <= 0) return;
@@ -1151,7 +1151,7 @@
 			if ($this->debug) {
 				$ptr = $this->lexer->ptr;
 				print "<b>Internal_CleanupWSByEatingInput:</b> input pointer is at $ptr; pattern=\"<tt>"
-					. htmlspecialchars($pattern) . "</tt>\"<br />\n";
+					. htmlspecialchars_54($pattern) . "</tt>\"<br />\n";
 			}
 
 			if (strlen($pattern) <= 0) return;
@@ -1199,7 +1199,7 @@
 		function Internal_CleanupWSByIteratingPointer($pattern, $pos, $array) {
 			if ($this->debug) {
 				print "<b>Internal_CleanupWSByIteratingPointer:</b> pointer is $pos; pattern=\"<tt>"
-					. htmlspecialchars($pattern) . "</tt>\"<br />\n";
+					. htmlspecialchars_54($pattern) . "</tt>\"<br />\n";
 			}
 
 			if (strlen($pattern) <= 0) return $pos;
@@ -1281,11 +1281,11 @@
 		//   $tag_name is the name of the tag being processed.
 		//
 		//   $default_value is the default value given; for example, in [url=foo], it's "foo".
-		//        This value has NOT been passed through htmlspecialchars().
+		//        This value has NOT been passed through htmlspecialchars_54().
 		//
 		//   $params is an array of key => value parameters associated with the tag; for example,
 		//        in [smiley src=smile alt=:-)], it's Array('src' => "smile", 'alt' => ":-)").
-		//        These keys and values have NOT beel passed through htmlspecialchars().
+		//        These keys and values have NOT beel passed through htmlspecialchars_54().
 		//
 		//   $contents is the body of the tag during BBCODE_OUTPUT.  For example, in
 		//        [b]Hello[/b], it's "Hello".  THIS VALUE IS ALWAYS HTML, not BBCode.
@@ -1300,7 +1300,7 @@
 
 			case BBCODE_CHECK:
 				if ($this->debug)
-					print "<b>DoTag:</b> check tag <tt>[" . htmlspecialchars($tag_name) . "]</tt><br />\n";
+					print "<b>DoTag:</b> check tag <tt>[" . htmlspecialchars_54($tag_name) . "]</tt><br />\n";
 
 				if (isset($tag_rule['allow'])) {
 					// An 'allow' array, if given, overrides the other check techniques.
@@ -1317,13 +1317,13 @@
 							else $value = @$tag_rule['default'][$param];
 						}
 						if ($this->debug) {
-							print "<b>DoTag:</b> check parameter <tt>\"" . htmlspecialchars($param)
-								. "\"</tt>, value <tt>\"" . htmlspecialchars($value) . "\", against \""
-								. htmlspecialchars($pattern) . "\"</tt><br />\n";
+							print "<b>DoTag:</b> check parameter <tt>\"" . htmlspecialchars_54($param)
+								. "\"</tt>, value <tt>\"" . htmlspecialchars_54($value) . "\", against \""
+								. htmlspecialchars_54($pattern) . "\"</tt><br />\n";
 						}
 						if (!preg_match($pattern, $value)) {
 							if ($this->debug) {
-								print "<b>DoTag:</b> parameter <tt>\"" . htmlspecialchars($param)
+								print "<b>DoTag:</b> parameter <tt>\"" . htmlspecialchars_54($param)
 									. "\"</tt> failed 'allow' check.<br />\n";
 							}
 							return false;
@@ -1360,7 +1360,7 @@
 				}
 				
 				if ($this->debug) {
-					print "<b>DoTag:</b> tag <tt>[" . htmlspecialchars($tag_name) . "]</tt> returned "
+					print "<b>DoTag:</b> tag <tt>[" . htmlspecialchars_54($tag_name) . "]</tt> returned "
 						. ($result ? "true" : "false") . "<br />\n";
 				}
 
@@ -1368,9 +1368,9 @@
 
 			case BBCODE_OUTPUT:
 				if ($this->debug) {
-					print "<b>DoTag:</b> output tag <tt>[" . htmlspecialchars($tag_name)
+					print "<b>DoTag:</b> output tag <tt>[" . htmlspecialchars_54($tag_name)
 						. "]</tt>: contents=<tt>"
-						. htmlspecialchars($contents) . "</tt><br />\n";
+						. htmlspecialchars_54($contents) . "</tt><br />\n";
 				}
 
 				if ($this->plain_mode) {
@@ -1391,7 +1391,7 @@
 						}
 						if (isset($params[$possible_content])
 							&& strlen($params[$possible_content]) > 0) {
-							$result = htmlspecialchars($params[$possible_content]);
+							$result = htmlspecialchars_54($params[$possible_content]);
 							break;
 						}
 					}
@@ -1399,9 +1399,9 @@
 					if ($this->debug) {
 						$content_list = "";
 						foreach ($plain_content as $possible_content)
-							$content_list .= htmlspecialchars($possible_content) . ",";
+							$content_list .= htmlspecialchars_54($possible_content) . ",";
 						print "<b>DoTag:</b> plain-mode tag; possible contents were ($content_list); using \""
-							. htmlspecialchars($possible_content) . "\"<br />\n";
+							. htmlspecialchars_54($possible_content) . "\"<br />\n";
 					}
 
 					$start = @$tag_rule['plain_start'];
@@ -1463,8 +1463,8 @@
 				}
 
 				if ($this->debug) {
-					print "<b>DoTag:</b> output tag <tt>[" . htmlspecialchars($tag_name)
-						. "]</tt>: result=<tt>" . htmlspecialchars($result) . "</tt><br />\n";
+					print "<b>DoTag:</b> output tag <tt>[" . htmlspecialchars_54($tag_name)
+						. "]</tt>: result=<tt>" . htmlspecialchars_54($result) . "</tt><br />\n";
 				}
 
 				return $result;
@@ -1514,7 +1514,7 @@
 		// Process an isolated tag, a tag that is not allowed to have an end tag.
 		function Internal_ProcessIsolatedTag($tag_name, $tag_params, $tag_rule) {
 			if ($this->debug) {
-				print "<b>ProcessIsolatedTag:</b> tag <tt>[" . htmlspecialchars($tag_name)
+				print "<b>ProcessIsolatedTag:</b> tag <tt>[" . htmlspecialchars_54($tag_name)
 					. "]</tt> is isolated: no end tag allowed, so processing immediately.<br />\n";
 			}
 
@@ -1522,7 +1522,7 @@
 			// the option to say, no, I'm broken, don't try to process me.
 			if (!$this->DoTag(BBCODE_CHECK, $tag_name, @$tag_params['_default'], $tag_params, "")) {
 				if ($this->debug) {
-					print "<b>ProcessIsolatedTag:</b> isolated tag <tt>[" . htmlspecialchars($tag_name)
+					print "<b>ProcessIsolatedTag:</b> isolated tag <tt>[" . htmlspecialchars_54($tag_name)
 						. "]</tt> rejected its parameters; outputting as text after fixup.<br />\n";
 				}
 				$this->stack[] = Array(
@@ -1539,8 +1539,8 @@
 			$this->Internal_CleanupWSByEatingInput(@$tag_rule['after_tag']);
 
 			if ($this->debug) {
-				print "<b>ProcessIsolatedTag:</b> isolated tag <tt>[" . htmlspecialchars($tag_name)
-					. "]</tt> is done; pushing its output: <tt>" . htmlspecialchars($output) . "</tt><br />\n";
+				print "<b>ProcessIsolatedTag:</b> isolated tag <tt>[" . htmlspecialchars_54($tag_name)
+					. "]</tt> is done; pushing its output: <tt>" . htmlspecialchars_54($output) . "</tt><br />\n";
 			}
 
 			$this->stack[] = Array(
@@ -1564,7 +1564,7 @@
 			$end_tag = $this->lexer->tagmarker . "/" . $tag_name . $this->lexer->end_tagmarker;
 
 			if ($this->debug) {
-				print "<b>Internal_ProcessVerbatimTag:</b> tag <tt>[" . htmlspecialchars($tag_name)
+				print "<b>Internal_ProcessVerbatimTag:</b> tag <tt>[" . htmlspecialchars_54($tag_name)
 					. "]</tt> uses verbatim content: searching for $end_tag...<br />\n";
 			}
 
@@ -1579,7 +1579,7 @@
 				}
 				if ($this->debug) {
 					print "<b>Internal_ProcessVerbatimTag:</b> push: <tt>"
-						. htmlspecialchars($this->lexer->text) . "</tt><br />\n";
+						. htmlspecialchars_54($this->lexer->text) . "</tt><br />\n";
 				}
 
 				// If this token pushes us past the output limit, split it up on a whitespace
@@ -1604,7 +1604,7 @@
 
 				$this->stack[] = Array(
 					BBCODE_STACK_TOKEN => $token_type,
-					BBCODE_STACK_TEXT => htmlspecialchars($this->lexer->text),
+					BBCODE_STACK_TEXT => htmlspecialchars_54($this->lexer->text),
 					BBCODE_STACK_TAG => $this->lexer->tag,
 					BBCODE_STACK_CLASS => $this->current_class,
 				);
@@ -1663,8 +1663,8 @@
 				@$tag_params['_default'], $tag_params, $content);
 
 			if ($this->debug) {
-				print "<b>Internal_ProcessVerbatimTag:</b> end of verbatim <tt>[" . htmlspecialchars($tag_name)
-					. "]</tt> tag processing; push output as text: <tt>" . htmlspecialchars($output)
+				print "<b>Internal_ProcessVerbatimTag:</b> end of verbatim <tt>[" . htmlspecialchars_54($tag_name)
+					. "]</tt> tag processing; push output as text: <tt>" . htmlspecialchars_54($output)
 					. "</tt><br />\n";
 			}
 
@@ -1686,13 +1686,13 @@
 			$tag_name = @$tag_params['_name'];
 			if ($this->debug) {
 				print "<hr />\n<b>Internal_ParseStartTagToken:</b> got tag <tt>["
-					. htmlspecialchars($tag_name) . "]</tt>.<br />\n";
+					. htmlspecialchars_54($tag_name) . "]</tt>.<br />\n";
 			}
 
 			// Make sure this tag has been defined.
 			if (!isset($this->tag_rules[$tag_name])) {
 				if ($this->debug) {
-					print "<b>Internal_ParseStartTagToken:</b> tag <tt>[" . htmlspecialchars($tag_name)
+					print "<b>Internal_ParseStartTagToken:</b> tag <tt>[" . htmlspecialchars_54($tag_name)
 						. "]</tt> does not exist; pushing as text after fixup.<br />\n";
 				}
 				// If there is no such tag with this name, then just push the text as
@@ -1715,8 +1715,8 @@
 			if (!in_array($this->current_class, $allow_in)) {
 				// Not allowed.  Rewind the stack backward until it is allowed.
 				if ($this->debug) {
-					print "<b>Internal_ParseStartTagToken:</b> tag <tt>[" . htmlspecialchars($tag_name)
-						. "]</tt> is disallowed inside class <tt>" . htmlspecialchars($this->current_class)
+					print "<b>Internal_ParseStartTagToken:</b> tag <tt>[" . htmlspecialchars_54($tag_name)
+						. "]</tt> is disallowed inside class <tt>" . htmlspecialchars_54($this->current_class)
 						. "</tt>; rewinding stack to a safe class.<br />\n";
 				}
 				if (!$this->Internal_RewindToClass($allow_in)) {
@@ -1751,7 +1751,7 @@
 			// push this tag on the stack and defer its processing until we see its end tag.
 
 			if ($this->debug) {
-				print "<b>Internal_ParseStartTagToken:</b> tag <tt>[" . htmlspecialchars($tag_name)
+				print "<b>Internal_ParseStartTagToken:</b> tag <tt>[" . htmlspecialchars_54($tag_name)
 					. "]</tt> is allowed to have an end tag.<br />\n";
 			}
 
@@ -1759,7 +1759,7 @@
 			// to say, no, I'm broken, don't try to process me.
 			if (!$this->DoTag(BBCODE_CHECK, $tag_name, @$tag_params['_default'], $tag_params, "")) {
 				if ($this->debug) {
-					print "<b>Internal_ParseStartTagToken:</b> tag <tt>[" . htmlspecialchars($tag_name)
+					print "<b>Internal_ParseStartTagToken:</b> tag <tt>[" . htmlspecialchars_54($tag_name)
 						. "]</tt> rejected its parameters; outputting as text after fixup.<br />\n";
 				}
 				$this->stack[] = Array(
@@ -1787,8 +1787,8 @@
 			else $newclass = $this->root_class;
 			
 			if ($this->debug) {
-				print "<b>Internal_ParseStartTagToken:</b> pushing tag <tt>[" . htmlspecialchars($tag_name)
-					. "]</tt> onto stack; switching to class <tt>" . htmlspecialchars($newclass)
+				print "<b>Internal_ParseStartTagToken:</b> pushing tag <tt>[" . htmlspecialchars_54($tag_name)
+					. "]</tt> onto stack; switching to class <tt>" . htmlspecialchars_54($newclass)
 					. "</tt>.<br />\n";
 			}
 
@@ -1811,7 +1811,7 @@
 			$tag_name = @$tag_params['_name'];
 			if ($this->debug) {
 				print "<hr />\n<b>Internal_ParseEndTagToken:</b> got end tag <tt>[/"
-					. htmlspecialchars($tag_name) . "]</tt>.<br />\n";
+					. htmlspecialchars_54($tag_name) . "]</tt>.<br />\n";
 			}
 
 			// Got an end tag.  Walk down the stack and see if there's a matching
@@ -1825,7 +1825,7 @@
 				// otherwise, just output this end tag itself as plain text.
 				if ($this->debug) {
 					print "<b>Internal_ParseEndTagToken:</b> no start tag for <tt>[/"
-						. htmlspecialchars($tag_name) . "]</tt>; push as text after fixup.<br />\n";
+						. htmlspecialchars_54($tag_name) . "]</tt>; push as text after fixup.<br />\n";
 				}
 				if (@$this->lost_start_tags[$tag_name] > 0) {
 					$this->lost_start_tags[$tag_name]--;
@@ -1858,8 +1858,8 @@
 			
 			if ($this->debug) {
 				print "<b>Internal_ParseEndTagToken:</b> end tag <tt>[/"
-					. htmlspecialchars($tag_name) . "]</tt> done; push output: <tt>"
-					. htmlspecialchars($output) . "</tt><br />\n";
+					. htmlspecialchars_54($tag_name) . "]</tt> done; push output: <tt>"
+					. htmlspecialchars_54($output) . "</tt><br />\n";
 			}
 
 			$this->stack[] = Array(
@@ -1882,7 +1882,7 @@
 
 			if ($this->debug) {
 				print "<b>Parse Begin:</b> input string is " . strlen($string) . " characters long:<br />\n"
-					. "<b>Parse:</b> input: <tt>" . htmlspecialchars(addcslashes($string, "\x00..\x1F\\\"'"))
+					. "<b>Parse:</b> input: <tt>" . htmlspecialchars_54(addcslashes($string, "\x00..\x1F\\\"'"))
 					. "</tt><br />\n";
 			}
 
@@ -1972,7 +1972,7 @@
 					// won't know what to do with it until we reach an operator (e.g., a tag or EOI).
 					if ($this->debug) {
 						print "<hr />\n<b>Internal_ParseTextToken:</b> fixup and push text: <tt>"
-							. htmlspecialchars($this->lexer->text) . "</tt><br />\n";
+							. htmlspecialchars_54($this->lexer->text) . "</tt><br />\n";
 					}
 
 					// If this token pushes us past the output limit, split it up on a whitespace
@@ -2131,7 +2131,7 @@
 			}
 
 			if ($this->debug) {
-				print "<b>Parse:</b> return: <tt>" . htmlspecialchars(addcslashes($result, "\x00..\x1F\\\"'"))
+				print "<b>Parse:</b> return: <tt>" . htmlspecialchars_54(addcslashes($result, "\x00..\x1F\\\"'"))
 					. "</tt><br />\n";
 			}
 


### PR DESCRIPTION
This PR attempts to cleanly apply the `.games` TLD changes to this library.

See https://gntech.zendesk.com/agent/tickets/3268

Essentially this is to fix a bug where `email@domain.games` was being auto linked as `<a href="mailto:email@domain.ga">email@domain.ga</a>mes`.

A previous NBBC 'fix' had broken pull https://github.com/gamernetwork/NBBC/pull/2 by modifying the output file from the build process, and not modifying the input source files.

I have done this to untangle the mess.

 - reverting htmlspecialchars54 bodging and whitespace changes in generated nbbc.php
 - modifying source files to correctly include htmlspecialchars_54 bodge
 - rebuilding the generated file (using tools/Makefile)
 - moving a hungry [a-z]{2} which would match `.ga` before `.games`

It's a little hard to read this as a previous commit introduced a lot of whitespace changes (grrr).

I have tested (so far) with, you may do the same:

 - linter `php -l`
 - https://mark-gamesindustry-jobs-propjoe.dev.gamer-network.net/well-played-games/uk-and-europe/cloud-engineer-id107207

